### PR TITLE
Fix wrong sublist indices, this meant it was not possible to

### DIFF
--- a/src/main/kotlin/com/redhat/mqe/main.kt
+++ b/src/main/kotlin/com/redhat/mqe/main.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 fun main(args: Array<String>) {
     when (args[0]) {
         "runBrokerSystemTests" -> runBrokerSystemTests()
-        "compressJUnit" -> compressJUnit(args.slice(1..args.size))
+        "compressJUnit" -> compressJUnit(args.slice(1 until args.size))
         else -> throw IllegalArgumentException("Specified operation is not implemented")
     }
 }


### PR DESCRIPTION
run without specifying the special directory name.